### PR TITLE
dts: helios4: partition spi flash for U-Boot

### DIFF
--- a/arch/arm/boot/dts/armada-388-helios4.dts
+++ b/arch/arm/boot/dts/armada-388-helios4.dts
@@ -265,6 +265,11 @@
 					spi-max-frequency = <104000000>;
 					spi-cpha;
 					status = "okay";
+
+					u-boot@0 {
+						label = "U-Boot";
+						reg = <0 0x110000>;
+					};
 				};
 			};
 


### PR DESCRIPTION
Reserve first 0x110000 bytes of SPI flash for U-Boot.
Binary of u-boot-2013.01-15t1-helios4 uses 0xD7528 bytes (03/01/2018);
Environment is located at 0x100000, up to 0x110000.
This means U-Boot needs at least the first 0x110000 bytes on SPI flash for itself.

Signed-off-by: Josua Mayer <josua.mayer97@gmail.com>

This creates /dev/mtdblock0 so we can write U-Boot to it!

```
BootROM - 1.73
Booting from SPI flash


General initialization - Version: 1.0.0
AVS selection from EFUSE disabled (Skip reading EFUSE values)
Overriding default AVS value to: 0x23
Detected Device ID 6828
High speed PHY - Version: 2.0

Init Customer board board SerDes lanes topology details:
 | Lane # | Speed|    Type     |
 ------------------------------|
 |   0    |  3   |  SATA0      |
 |   1    |  5   |  USB3 HOST0 |
 |   2    |  3   |  SATA1      |
 |   3    |  3   |  SATA3      |
 |   4    |  3   |  SATA2      |
 |   5    |  5   |  USB3 HOST1 |
 -------------------------------
High speed PHY - Ended Successfully
DDR3 Training Sequence - Ver TIP-1.46.0
DDR3 Training Sequence - Switching XBAR Window to FastPath Window 
DDR Training Sequence - Start scrubbing 
DDR Training Sequence - End scrubbing 
DDR3 Training Sequence - Ended Successfully
BootROM: Image checksum verification PASSED

 __   __                      _ _
|  \/  | __ _ _ ____   _____| | |
| |\/| |/ _` | '__\ \ / / _ \ | |
| |  | | (_| | |   \ V /  __/ | |
|_|  |_|\__,_|_|    \_/ \___|_|_|
         _   _     ____              _
        | | | |   | __ )  ___   ___ | |_ 
        | | | |___|  _ \ / _ \ / _ \| __| 
        | |_| |___| |_) | (_) | (_) | |_ 
         \___/    |____/ \___/ \___/ \__| 
 ** LOADER **


U-Boot 2013.01-g9154b7688e1-dirty (Jan 02 2018 - 18:11:49) Marvell version: 2015_T1.0p16

Board: Helios4
SoC:   MV88F6828 Rev A0
       running 2 CPUs
CPU:   ARM Cortex A9 MPCore (Rev 1) LE
       CPU 0
       CPU    @ 1600 [MHz]
       L2     @ 800 [MHz]
       TClock @ 250 [MHz]
       DDR3    @ 800 [MHz]
       DDR3 32 Bit Width,FastPath Memory Access, DLB Enabled, ECC Enabled
DRAM:  2 GiB
MMC:   mv_sdh: 0
SF: Detected W25Q32 with page size 4 KiB, total 4 MiB
*** Warning - bad CRC, using default environment

USB2.0 0: Host Mode
USB3.0 0: Host Mode
USB3.0 1: Host Mode

Map:   Code:                    0x7fee5000:0x7ff98524
       BSS:                     0x7ffeff04
       Stack:                   0x7f9d4f20
       Heap:                    0x7f9d5000:0x7fee5000
       U-Boot Environment:      0x00100000:0x00110000 (SPI)

Board configuration detected:
Net:   
|  port  | Interface | PHY address  |
|--------|-----------|--------------|
| egiga0 |   RGMII   |     0x00     |
egiga0 [PRIME]
Hit any key to stop autoboot:  0
```