### PR TITLE
improve mvebu pwm to handle more than one GPIO in  a PWM set

### DIFF
--- a/Documentation/devicetree/bindings/gpio/gpio-mvebu.txt
+++ b/Documentation/devicetree/bindings/gpio/gpio-mvebu.txt
@@ -78,7 +78,7 @@ Example:
 		};
 
 		gpio1: gpio@18140 {
-			compatible = "marvell,armada-370-xp-gpio";
+			compatible = "marvell,armada-370-gpio";
 			reg = <0x18140 0x40>, <0x181c8 0x08>;
 			reg-names = "gpio", "pwm";
 			ngpios = <17>;

--- a/arch/arm/boot/dts/armada-388-helios4.dts
+++ b/arch/arm/boot/dts/armada-388-helios4.dts
@@ -132,12 +132,12 @@
 
 	fan1: j10-pwm {
 		compatible = "pwm-fan";
-		pwms = <&gpio1 9 3000>;
+		pwms = <&gpio1 9 3800>;
 	};
 
 	fan2: j17-pwm {
 		compatible = "pwm-fan";
-		pwms = <&gpio1 4 4500>;
+		pwms = <&gpio1 23 3800>;
 	};
 
 	usb2_phy: usb2-phy {

--- a/arch/arm/boot/dts/armada-388-helios4.dts
+++ b/arch/arm/boot/dts/armada-388-helios4.dts
@@ -10,6 +10,8 @@
 #include "armada-388.dtsi"
 #include "armada-38x-solidrun-microsom.dtsi"
 
+#include <dt-bindings/thermal/thermal.h>
+
 / {
 	model = "Helios4";
 	compatible = "marvell,armada388",
@@ -132,12 +134,60 @@
 
 	fan1: j10-pwm {
 		compatible = "pwm-fan";
+		cooling-min-state = <0>;
+		cooling-max-state = <3>;
+		#cooling-cells = <2>;
 		pwms = <&gpio1 9 3800>;
+		cooling-levels = <0 102 170 230>;
 	};
 
 	fan2: j17-pwm {
 		compatible = "pwm-fan";
+		cooling-min-state = <0>;
+		cooling-max-state = <3>;
+		#cooling-cells = <2>;
 		pwms = <&gpio1 23 3800>;
+		cooling-levels = <0 102 170 230>;
+	};
+
+	thermal-zones {
+		cpu_thermal: cpu-thermal {
+			polling-delay-passive = <0>;
+			polling-delay = <0>;
+
+			thermal-sensors = <&temp_sensor>;
+
+			trips {
+                                cpu_alert0: cpu_alert0 {
+                                        /* milliCelsius */
+                                        temperature = <70000>;
+                                        hysteresis = <2000>;
+                                        type = "active";
+                                };
+                                cpu_alert1: cpu_alert1 {
+                                        /* milliCelsius */
+                                        temperature = <75000>;
+                                        hysteresis = <2000>;
+                                        type = "passive";
+                                };
+                                cpu_crit: cpu_crit {
+                                        /* milliCelsius */
+                                        temperature = <80000>;
+                                        hysteresis = <2000>;
+                                        type = "critical";
+                                };
+			};
+			cooling-maps {
+				map0 {
+					trip = <&cpu_alert0>;
+					cooling-device = <&fan1 THERMAL_NO_LIMIT 1>;
+				};
+				map1 {
+					trip = <&cpu_alert1>;
+					cooling-device = <&fan1 2 THERMAL_NO_LIMIT>;
+				};
+			};
+		};
 	};
 
 	usb2_phy: usb2-phy {
@@ -207,6 +257,7 @@
 				temp_sensor: temp@4c {
 					compatible = "ti,lm75";
 					reg = <0x4c>;
+					#thermal-sensor-cells = <0>;
 					vcc-supply = <&reg_3p3v>;
 				};
 

--- a/arch/arm/boot/dts/armada-38x.dtsi
+++ b/arch/arm/boot/dts/armada-38x.dtsi
@@ -345,7 +345,7 @@
 			};
 
 			gpio0: gpio@18100 {
-				compatible = "marvell,armada-370-xp-gpio",
+				compatible = "marvell,armada-370-gpio",
 					     "marvell,orion-gpio";
 				reg = <0x18100 0x40>, <0x181c0 0x08>;
 				reg-names = "gpio", "pwm";
@@ -363,7 +363,7 @@
 			};
 
 			gpio1: gpio@18140 {
-				compatible = "marvell,armada-370-xp-gpio",
+				compatible = "marvell,armada-370-gpio",
 					     "marvell,orion-gpio";
 				reg = <0x18140 0x40>, <0x181c8 0x08>;
 				reg-names = "gpio", "pwm";

--- a/drivers/gpio/gpio-mvebu.c
+++ b/drivers/gpio/gpio-mvebu.c
@@ -595,6 +595,7 @@ static void mvebu_pwm_free(struct pwm_chip *chip, struct pwm_device *pwm)
 
 	spin_lock_irqsave(&mvpwm->lock, flags);
 	gpiod_free(mvpwm->gpiod);
+	mvpwm->gpiod = NULL;
 	mvpwm->used = false;
 	spin_unlock_irqrestore(&mvpwm->lock, flags);
 }

--- a/drivers/gpio/gpio-mvebu.c
+++ b/drivers/gpio/gpio-mvebu.c
@@ -89,12 +89,19 @@
 
 #define MVEBU_MAX_GPIO_PER_BANK		32
 
+struct mvebu_pwm_item {
+	struct gpio_desc	*gpiod;
+	spinlock_t		 lock;
+	unsigned int		 pin;
+	bool			 used;
+
+	struct list_head	 node;
+};
+
 struct mvebu_pwm {
 	void __iomem		*membase;
 	unsigned long		 clk_rate;
-	struct gpio_desc	*gpiod;
-	bool			 used;
-	unsigned int		 pin;
+	struct list_head	 pwms;
 	struct pwm_chip		 chip;
 	int			 id;
 	spinlock_t		 lock;
@@ -556,48 +563,58 @@ static int mvebu_pwm_request(struct pwm_chip *chip, struct pwm_device *pwm)
 	struct mvebu_pwm *mvpwm = to_mvebu_pwm(chip);
 	struct mvebu_gpio_chip *mvchip = mvpwm->mvchip;
 	struct gpio_desc *desc;
+	struct mvebu_pwm_item *item;
 	unsigned long flags;
 	int ret = 0;
 
-	spin_lock_irqsave(&mvpwm->lock, flags);
-	if (mvpwm->gpiod) {
-		ret = -EBUSY;
-	} else {
-		desc = gpio_to_desc(mvchip->chip.base + pwm->hwpwm);
-		if (!desc) {
-			ret = -ENODEV;
-			goto out;
-		}
-		ret = gpiod_request(desc, "mvebu-pwm");
-		if (ret)
-			goto out;
+	item = kzalloc(sizeof(*item), GFP_KERNEL);
+	if (!item)
+		return -ENODEV;
 
-		ret = gpiod_direction_output(desc, 0);
-		if (ret) {
-			gpiod_free(desc);
-			goto out;
-		}
-
-		mvpwm->gpiod = desc;
-		mvpwm->pin = pwm->pwm - mvchip->chip.base;
-		mvpwm->used = true;
+	desc = gpio_to_desc(mvchip->chip.base + pwm->hwpwm);
+	if (!desc) {
+		ret = -ENODEV;
+		goto out;
 	}
 
-out:
+	ret = gpiod_request(desc, "mvebu-pwm");
+	if (ret)
+		goto out;
+
+	ret = gpiod_direction_output(desc, 0);
+	if (ret) {
+		gpiod_free(desc);
+		goto out;
+	}
+
+	spin_lock_irqsave(&mvpwm->lock, flags);
+	item->gpiod = desc;
+	item->pin = pwm->pwm - mvchip->chip.base;
+	item->used = true;
 	spin_unlock_irqrestore(&mvpwm->lock, flags);
+
+	list_add_tail(&item->node, &mvpwm->pwms);
+
+out:
 	return ret;
 }
 
 static void mvebu_pwm_free(struct pwm_chip *chip, struct pwm_device *pwm)
 {
 	struct mvebu_pwm *mvpwm = to_mvebu_pwm(chip);
+	struct mvebu_pwm_item *item, *tmp;
 	unsigned long flags;
 
-	spin_lock_irqsave(&mvpwm->lock, flags);
-	gpiod_free(mvpwm->gpiod);
-	mvpwm->gpiod = NULL;
-	mvpwm->used = false;
-	spin_unlock_irqrestore(&mvpwm->lock, flags);
+	list_for_each_entry_safe_reverse(item, tmp, &mvpwm->pwms, node) {
+		gpiod_free(item->gpiod);
+		spin_lock_irqsave(&mvpwm->lock, flags);
+		item->gpiod = NULL;
+		item->used = false;
+		spin_unlock_irqrestore(&mvpwm->lock, flags);
+
+		list_del(&item->node);
+		kfree(item);
+	}
 }
 
 static int mvebu_pwm_config(struct pwm_chip *chip, struct pwm_device *pwmd,
@@ -605,6 +622,7 @@ static int mvebu_pwm_config(struct pwm_chip *chip, struct pwm_device *pwmd,
 {
 	struct mvebu_pwm *pwm = to_mvebu_pwm(chip);
 	struct mvebu_gpio_chip *mvchip = pwm->mvchip;
+	struct mvebu_pwm_item *item;
 	unsigned int on, off;
 	unsigned long long val;
 	u32 u;
@@ -628,8 +646,10 @@ static int mvebu_pwm_config(struct pwm_chip *chip, struct pwm_device *pwmd,
 		off = 1;
 
 	u = readl_relaxed(mvebu_gpioreg_blink_select(mvchip));
-	u &= ~(1 << pwm->pin);
-	u |= (pwm->id << pwm->pin);
+	list_for_each_entry(item, &pwm->pwms, node)
+		u &= ~(1 << item->pin);
+	list_for_each_entry(item, &pwm->pwms, node)
+		u |= (pwm->id << item->pin);
 	writel_relaxed(u, mvebu_gpioreg_blink_select(mvchip));
 
 	writel_relaxed(on, mvebu_pwmreg_blink_on_duration(pwm));
@@ -642,8 +662,10 @@ static int mvebu_pwm_enable(struct pwm_chip *chip, struct pwm_device *pwm)
 {
 	struct mvebu_pwm *mvpwm = to_mvebu_pwm(chip);
 	struct mvebu_gpio_chip *mvchip = mvpwm->mvchip;
+	struct mvebu_pwm_item *item;
 
-	mvebu_gpio_blink(&mvchip->chip, mvpwm->pin, 1);
+	list_for_each_entry(item, &mvpwm->pwms, node)
+		mvebu_gpio_blink(&mvchip->chip, item->pin, 1);
 
 	return 0;
 }
@@ -652,8 +674,10 @@ static void mvebu_pwm_disable(struct pwm_chip *chip, struct pwm_device *pwm)
 {
 	struct mvebu_pwm *mvpwm = to_mvebu_pwm(chip);
 	struct mvebu_gpio_chip *mvchip = mvpwm->mvchip;
+	struct mvebu_pwm_item *item;
 
-	mvebu_gpio_blink(&mvchip->chip, mvpwm->pin, 0);
+	list_for_each_entry(item, &mvpwm->pwms, node)
+		mvebu_gpio_blink(&mvchip->chip, item->pin, 0);
 }
 
 static const struct pwm_ops mvebu_pwm_ops = {
@@ -735,6 +759,7 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
 	mvpwm = devm_kzalloc(dev, sizeof(struct mvebu_pwm), GFP_KERNEL);
 	if (!mvpwm)
 		return -ENOMEM;
+	INIT_LIST_HEAD(&mvpwm->pwms);
 	mvpwm->id = id;
 	mvchip->mvpwm = mvpwm;
 	mvpwm->mvchip = mvchip;

--- a/drivers/gpio/gpio-mvebu.c
+++ b/drivers/gpio/gpio-mvebu.c
@@ -730,11 +730,11 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
 	else
 		return -EINVAL;
 	writel_relaxed(set, mvebu_gpioreg_blink_select(mvchip));
-	mvpwm->id = id;
 
 	mvpwm = devm_kzalloc(dev, sizeof(struct mvebu_pwm), GFP_KERNEL);
 	if (!mvpwm)
 		return -ENOMEM;
+	mvpwm->id = id;
 	mvchip->mvpwm = mvpwm;
 	mvpwm->mvchip = mvchip;
 

--- a/drivers/gpio/gpio-mvebu.c
+++ b/drivers/gpio/gpio-mvebu.c
@@ -752,6 +752,14 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
 	mvpwm->chip.ops = &mvebu_pwm_ops;
 	mvpwm->chip.npwm = mvchip->chip.ngpio;
 
+	/*
+	 * There may already be some PWM allocated, so we can't force
+	 * mvpwm->chip.base to a fixed point like mvchip->chip.base.
+	 * So, we let pwmchip_add() do the numbering and take the next free
+	 * region.
+	 */
+	mvpwm->chip.base = -1;
+
 	spin_lock_init(&mvpwm->lock);
 
 	return pwmchip_add(&mvpwm->chip);


### PR DESCRIPTION
I let gpio-mvebu driver handle a list of GPIO per set (each set having its own PWM handling).
As I want to keep the two fans at same speed and policy this is fine to me. And this free the remaining PWM for other GPIOs to use.
The rough edge is that pwm-fan is not modified to cope. Thus if we set pwm1 to value X on fan1 both fn1 and fan2 ens up at setting X  but if we cat their sysfs files fan2 will still returns the old value.

There is a sample devicetree thermal policy you might want to tweak.

Note I only tested the patchset above armbian upstream build.